### PR TITLE
Make SPI-Interface changeable from example code

### DIFF
--- a/example/Example_Distance_To_Terminal/main.py
+++ b/example/Example_Distance_To_Terminal/main.py
@@ -4,7 +4,7 @@ import array
 import network
 import mip
 
-from machine import Pin
+from machine import Pin, SPI
 
 # Libraries can be installed
 # using the MIP via 2 Methods.
@@ -38,8 +38,19 @@ bandwidth = const(2_000_000) # in kHz
 threshold_for_lower_freq = const(45.0)
 threshold_for_upper_freq = const(24.5)
 
+# set spi interface for communication
+spi_interface = SPI(
+        baudrate=50_000_000, 
+        polarity=0, 
+        phase=0, 
+        bits=8, 
+        firstbit=SPI.MSB, 
+        sck='P12_2', 
+        mosi='P12_0', 
+        miso='P12_1')
+
 # set radar sensor and standard config
-radar_sensor = BGT.BGT60TRxxModule(words)
+radar_sensor = BGT.BGT60TRxxModule(words, spi_interface, Pin("P12_3"), Pin("P11_1"), Pin("P11_0"))
 radar_sensor.set_adc_div(ADC_DIV)
 radar_sensor.set_chirp_len(samples_per_chirp)
 

--- a/example/Example_Plot_Range/main.py
+++ b/example/Example_Plot_Range/main.py
@@ -4,7 +4,7 @@ import array
 import network
 import mip
 
-from machine import Pin
+from machine import Pin, SPI
 
 # Libraries can be installed
 # using the MIP via 2 Methods.
@@ -38,8 +38,19 @@ bandwidth = const(2_000_000) # in kHz
 threshold_for_lower_freq = const(47.0)
 threshold_for_upper_freq = const(29.0)
 
+# set spi interface for communication
+spi_interface = SPI(
+        baudrate=50_000_000, 
+        polarity=0, 
+        phase=0, 
+        bits=8, 
+        firstbit=SPI.MSB, 
+        sck='P12_2', 
+        mosi='P12_0', 
+        miso='P12_1')
+
 # set radar sensor and standard config
-radar_sensor = BGT.BGT60TRxxModule(words)
+radar_sensor = BGT.BGT60TRxxModule(words, spi_interface, Pin("P12_3"), Pin("P11_1"), Pin("P11_0"))
 radar_sensor.set_adc_div(ADC_DIV)
 radar_sensor.set_chirp_len(samples_per_chirp)
 

--- a/micropython-radar-bgt60/BGT60TRXX.py
+++ b/micropython-radar-bgt60/BGT60TRXX.py
@@ -13,21 +13,13 @@ import dftclass as DFT
 class BGT60TRxxModule:
   """Implementation of an BGT60-Radar sensor using one antenna"""
 
-  def __init__(self, word_size: int, interrupt_handler=None):
+  def __init__(self, word_size: int, spi_interface: SPI, chip_select: Pin, reset: Pin, interrupt_pin: Pin = None, interrupt_handler=None):
     # Create SPI Peripheral with 50 MHz
     #=========================================
-    self.spi = SPI(
-        baudrate=50_000_000, 
-        polarity=0, 
-        phase=0, 
-        bits=8, 
-        firstbit=SPI.MSB, 
-        sck='P12_2', 
-        mosi='P12_0', 
-        miso='P12_1')
+    self.spi = spi_interface
     
-    self.cs = Pin("P12_3", mode=Pin.OUT, value=1)
-    self.reset_radar = Pin("P11_1", mode=Pin.OUT, value=1)
+    self.cs = Pin(chip_select, mode=Pin.OUT, value=1)
+    self.reset_radar = Pin(reset, mode=Pin.OUT, value=1)
 
     # Transfer of SPI Interface
     #============================
@@ -62,7 +54,7 @@ class BGT60TRxxModule:
     # Enable Interrupt Request when a Function is given
     #===================================================
     if(interrupt_handler is not None):
-      self.irq_radar = Pin("P11_0", 
+      self.irq_radar = Pin(interrupt_pin, 
                            mode=Pin.IN, 
                            pull=Pin.PULL_UP)
       self.irq_radar.irq(handler=interrupt_handler,


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Pins from SPI-Interface could not be changed before.
The user now has to create the spi interface and init the radar sensor with it.
That way, pins can be changed for other boards